### PR TITLE
Fix constructor argument type

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -1,6 +1,6 @@
 import { fetchRates } from "./parts/requester";
-import { Provider, providers, UserDefinedProvider } from "./parts/providers";
-import { Config, initializationConfig } from "./parts/config";
+import { Provider, ProviderReference } from "./parts/providers";
+import { Config } from "./parts/config";
 export { Chainer as Convert } from "./parts/chainer";
 import _to from "await-to-js";
 
@@ -31,10 +31,10 @@ export class Converter {
 
   /**
    * Creates an instance of Converter and initializes the config.
-   * @param {initializationConfig} config - base config
+   * @param {ProviderReference} config - base config
    * @memberof Converter
    */
-  constructor(...config: initializationConfig[] | undefined[] | string[]) {
+  constructor(...config: ProviderReference[] | undefined[] | string[]) {
     this.config = new Config(...config);
 
     // Forwarding config adder function (with the alternative handle)

--- a/src/parts/config.ts
+++ b/src/parts/config.ts
@@ -2,20 +2,11 @@ import {
   Provider,
   providers,
   resolveProvider,
-  UserDefinedProvider
+  UserDefinedProvider,
+  ProviderReference
 } from "./providers";
 
 import { checkIfUserDefinedProvider } from "./utils";
-
-/**
- * Interface for the format of data passed in to the module initially.
- *
- * @interface initializationConfig
- */
-export interface initializationConfig {
-  key: any;
-  provider: string;
-}
 
 /**
  * Config object that initializes with configuration data
@@ -134,7 +125,7 @@ export class Config {
    * @param {(object | undefined)} config
    * @memberof Config
    */
-  constructor(...config: initializationConfig[] | undefined[] | string[]) {
+  constructor(...config: ProviderReference[] | undefined[] | string[]) {
     this._active = resolveProviders(...config);
 
     // adding default fallback
@@ -150,7 +141,7 @@ export class Config {
  * @returns {config} - normalized configuration object
  */
 export function resolveProviders(
-  ...configuration: initializationConfig[] | undefined[] | string[]
+  ...configuration: ProviderReference[] | undefined[] | string[]
 ): Provider[] {
   // resolve default if none provided.
   if (typeof configuration === "undefined" || !configuration.length) {
@@ -174,7 +165,7 @@ export function resolveProviders(
 
   // configuration is an array of providers
   // casting
-  const initializationConfig = <initializationConfig[]>configuration;
+  const initializationConfig = <ProviderReference[]>configuration;
 
   // resolving all providers
   return initializationConfig.map((provider) => resolveProvider(provider));

--- a/src/parts/providers.ts
+++ b/src/parts/providers.ts
@@ -83,6 +83,11 @@ export interface Provider {
   errorHandler: Function;
 }
 
+export interface ProviderReference {
+  name: string;
+  key: any;
+}
+
 /**
  * A function that constructs provider based on raw input data.
  *
@@ -90,7 +95,7 @@ export interface Provider {
  * @param {*} provider object containing provider name and api key
  * @returns {Provider} constructed provider
  */
-export function resolveProvider(provider: any): Provider {
+export function resolveProvider(provider: ProviderReference): Provider {
   const existentProvider = providers[provider.name];
   if (!existentProvider) {
     throw "No provider with this name. Please use a provider from the supported providers list.";


### PR DESCRIPTION
The constructor argument typing is incorrect. This wasn't picked up by TypeScript because the consumer of the initializationConfig interface typed its argument as any, but it causes issues when trying to use this package in TypeScript projects.